### PR TITLE
Update url-parse to address security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9165,9 +9165,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "dev": true,
       "requires": {
         "querystringify": "^2.0.0",


### PR DESCRIPTION
When I did `npm install` just now after a fresh clone, npm advised running `npm audit` and `npm audit fix`. This is the result of that.

https://nodesecurity.io/advisories/678