### PR TITLE
Fix an error for adding assignees if failed to add reviewers.

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -40,17 +40,25 @@ export async function handlePullRequest (context: Context): Promise<void> {
   let result: Promise<any>
 
   if (config.addReviewers) {
-    result = await pullRequest.addReviewers(owner, repo, prNumber, reviewers)
-    context.log(result)
+    try {
+      result = await pullRequest.addReviewers(owner, repo, prNumber, reviewers)
+      context.log(result)
+    } catch (error) {
+      context.log(error)
+    }
   }
 
   if (config.addAssignees) {
-    const assignees: string[] = config.assignees ?
-      chooseUsers(owner, config.assignees, config.numberOfAssignees || config.numberOfReviewers)
-      :
-      reviewers
+    try {
+      const assignees: string[] = config.assignees ?
+        chooseUsers(owner, config.assignees, config.numberOfAssignees || config.numberOfReviewers)
+        :
+        reviewers
 
-    result = await pullRequest.addAssignees(owner, repo, prNumber, assignees)
-    context.log(result)
+      result = await pullRequest.addAssignees(owner, repo, prNumber, assignees)
+      context.log(result)
+    } catch (error) {
+      context.log(error)
+    }
   }
 }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -10,7 +10,7 @@ describe('chooseUsers', () => {
 
     expect(list).toEqual(['reviewer1','reviewer2', 'reviewer3'])
   })
-  
+
   test('returns the only other reviewer', () => {
     const owner = 'owner'
     const reviewers = ['owner','reviewer1']


### PR DESCRIPTION
### Description
This change is adding assignees if failed to add reviewers.

Before this change, if failed to review request, throw an error and exit process. As a result, not add assignees to pull request.