### PR TITLE
Allow adding pr author to assignees

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -34,7 +34,7 @@ export async function handlePullRequest (context: Context): Promise<void> {
 
   let result: any
 
-  if (config.addReviewers) {
+  if (config.addReviewers && reviewers.length > 0) {
     try {
       const params = context.issue({
         reviewers
@@ -46,7 +46,7 @@ export async function handlePullRequest (context: Context): Promise<void> {
     }
   }
 
-  if (config.addAssignees) {
+  if (config.addAssignees && reviewers.length > 0) {
     try {
       const assignees: string[] = config.assignees ?
         chooseUsers(owner, config.assignees, config.numberOfAssignees || config.numberOfReviewers)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,10 +1,17 @@
 import _ from 'lodash'
 
 export function chooseUsers (owner: string, candidates: string[], desiredNumber: number): string[] {
+
+  // self-assign
+  if (candidates.length === 1) {
+    return candidates
+  }
+
   const withoutOwner = candidates.filter(
     reviewer => owner !== reviewer
   )
 
+  // all-assign
   if (desiredNumber === 0) {
     return withoutOwner
   }

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -186,6 +186,35 @@ describe('handlePullRequest', () => {
     expect(createReviewRequestSpy.mock.calls[0][0].reviewers[0]).toMatch(/reviewer/)
   })
 
+  test('adds assignees to pull requests if the assigness are only the owner', async () => {
+    context.config = jest.fn().mockImplementation(async () => {
+      return {
+        addAssignees: true,
+        addReviewers: true,
+        numberOfReviewers: 0,
+        reviewers: ['owner'],
+        skipKeywords: ['wip']
+      }
+    })
+
+    context.github.issues = {
+      // tslint:disable-next-line:no-empty
+      addAssignees: jest.fn().mockImplementation(async () => {})
+    } as any
+
+    context.github.pullRequests = {
+      // tslint:disable-next-line:no-empty
+      createReviewRequest: jest.fn().mockImplementation(async () => {})
+    } as any
+
+    const addAssigneesSpy = jest.spyOn(context.github.issues, 'addAssignees')
+
+    await handlePullRequest(context)
+
+    expect(addAssigneesSpy.mock.calls[0][0].assignees).toHaveLength(1)
+    expect(addAssigneesSpy.mock.calls[0][0].assignees[0]).toMatch(/owner/)
+  })
+
   test('adds assignees to pull requests if throws error to add reviewers', async () => {
     context.config = jest.fn().mockImplementation(async () => {
       return {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -30,6 +30,16 @@ describe('chooseUsers', () => {
 
     expect(list.length).toEqual(2)
   })
+
+  test('returns the only owner if if the number of reviewers is one', () => {
+    const owner = 'owner'
+    const reviewers = ['owner']
+    const numberOfReviewers = 0
+
+    const list = chooseUsers(owner, reviewers, numberOfReviewers)
+
+    expect(list.length).toEqual(1)
+  })
 })
 
 describe('includesSkipKeywords', () => {


### PR DESCRIPTION
On the specification of GitHub it is possible to add yourself to assignee, but it is impossible to add it to reviewer. However this app currently does not allow to add yourself to both assignee and reviewer.

Some people use this app alone, but with the current code it is not possible to use self-assign, so it can not be used.

I resolved this problem. 