### PR TITLE
Add Dockerfile to support for GitHub Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:10
+
+LABEL "com.github.actions.name"="Auto Assign"
+LABEL "com.github.actions.description"="Add reviewers/assignees to pull requests when pull requests are opened."
+LABEL "com.github.actions.icon"="user-plus"
+LABEL "com.github.actions.color"="blue"
+
+LABEL "repository"="https://github.com/kentaro-m/auto-assign"
+LABEL "homepage"="https://probot.github.io/apps/auto-assign/"
+LABEL "maintainer"="Kentaro Matsushita"
+
+ENV PATH=$PATH:/app/node_modules/.bin
+WORKDIR /app
+COPY . .
+RUN npm install --production && npm run build
+
+ENTRYPOINT ["probot", "receive"]
+CMD ["/app/lib/index.js"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ WEBHOOK_SECRET=development
 PRIVATE_KEY_PATH=.data/private-key.pem
 ```
 
+### GitHub Actions
+Add `.github/main.workflow` to the repository you want to run the app.
+
+```hcl
+workflow "Add reviewers/assignees to Pull Requests" {
+  on = "pull_request"
+  resolves = "Auto Assign"
+}
+
+action "Auto Assign" {
+  uses = "kentaro-m/auto-assign@master"
+  secrets = ["GITHUB_TOKEN"]
+}
+```
+
 ## Contributing
 
 If you have suggestions for how `auto-assign` could be improved, or want to report a bug, open an issue! We'd love all and any contributions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8233,14 +8233,14 @@
       }
     },
     "tslint-eslint-rules": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz",
-      "integrity": "sha512-qq2H/AU/FlFbQJKXuxhtIk+ni/nQu9jHHhsFKa6hnA0/n3zl1/RWRc3TVFlL8HfWFMzkST350VeTrFpy1u4OUg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
+      "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
       "dev": true,
       "requires": {
         "doctrine": "0.7.2",
         "tslib": "1.9.0",
-        "tsutils": "2.8.0"
+        "tsutils": "^3.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -8272,12 +8272,12 @@
           "dev": true
         },
         "tsutils": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
-          "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.8.0.tgz",
+          "integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
           "dev": true,
           "requires": {
-            "tslib": "^1.7.1"
+            "tslib": "^1.8.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "ts-jest": "^24.0.0",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.13.0",
-    "tslint-config-standard": "^7.1.0"
+    "tslint-config-standard": "^7.1.0",
+    "tslint-eslint-rules": "^5.4.0"
   },
   "engines": {
     "node": ">= 8.3.0"


### PR DESCRIPTION
## Description
* Add Dockerfile to support for GitHub Actions

<img width="793" alt="screen shot 2019-02-23 at 0 57 51" src="https://user-images.githubusercontent.com/7448569/53254116-126d5f80-3706-11e9-9876-bb310d5628b3.png">

## TODO
- [x] Update README.md
- [x] Fix an error occurring in build

```
> dtrace-provider@0.8.7 install /app/node_modules/dtrace-provider
> node-gyp rebuild || node suppress-error.js

gyp ERR! configure error 
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:484:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:406:16)
gyp ERR! stack     at F (/usr/local/lib/node_modules/npm/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/usr/local/lib/node_modules/npm/node_modules/which/which.js:80:29)
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/which.js:89:16
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:154:21)
gyp ERR! System Linux 4.15.0-1027-gcp
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /app/node_modules/dtrace-provider
gyp ERR! node -v v10.15.1
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok 
```
