### PR TITLE
fix(reviewers): filter out the PR sender

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,13 +24,19 @@ export async function handlePullRequest (context: Context): Promise<void> {
 
   const owner = payload.repository.owner.login
   const title = payload.pull_request.title
+  const sender = payload.sender.login
 
   if (config.skipKeywords && includesSkipKeywords(title, config.skipKeywords)) {
     context.log('skips adding reviewers')
     return
   }
 
-  const reviewers = chooseUsers(owner, config.reviewers, config.numberOfReviewers)
+  const reviewers = chooseUsers(
+    owner,
+    sender,
+    config.reviewers,
+    config.numberOfReviewers
+  )
 
   let result: any
 
@@ -48,10 +54,14 @@ export async function handlePullRequest (context: Context): Promise<void> {
 
   if (config.addAssignees && reviewers.length > 0) {
     try {
-      const assignees: string[] = config.assignees ?
-        chooseUsers(owner, config.assignees, config.numberOfAssignees || config.numberOfReviewers)
-        :
-        reviewers
+      const assignees: string[] = config.assignees
+        ? chooseUsers(
+            owner,
+            '',
+            config.assignees,
+            config.numberOfAssignees || config.numberOfReviewers
+          )
+        : reviewers
 
       const params = context.issue({
         assignees

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -50,10 +50,10 @@ export async function handlePullRequest (context: Context): Promise<void> {
     }
   }
 
-  const assignees: string[] = chooseUsers(
-    config.assignees || config.reviewers,
+  const assignees: string[] = config.assignees ? chooseUsers(
+    config.assignees,
     config.numberOfAssignees || config.numberOfReviewers
-  )
+  ) : reviewers
 
   if (config.addAssignees && assignees.length > 0) {
     try {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,26 +1,23 @@
 import _ from 'lodash'
 
 export function chooseUsers (
-  owner: string,
-  sender: string,
   candidates: string[],
-  desiredNumber: number
+  desiredNumber: number,
+  filterUser: string = ''
 ): string[] {
-  // self-assign
-  if (candidates.length === 1) {
-    return candidates
-  }
 
-  const withoutOwnerAndSender = candidates.filter(
-    reviewer => owner !== reviewer && sender !== reviewer
+  const filteredCandidates = candidates.filter(
+    reviewer => {
+      return reviewer !== filterUser
+    }
   )
 
   // all-assign
   if (desiredNumber === 0) {
-    return withoutOwnerAndSender
+    return filteredCandidates
   }
 
-  return _.sampleSize(withoutOwnerAndSender, desiredNumber)
+  return _.sampleSize(filteredCandidates, desiredNumber)
 }
 
 export function includesSkipKeywords (title: string, skipKeywords: string[]): boolean {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,22 +1,26 @@
 import _ from 'lodash'
 
-export function chooseUsers (owner: string, candidates: string[], desiredNumber: number): string[] {
-
+export function chooseUsers (
+  owner: string,
+  sender: string,
+  candidates: string[],
+  desiredNumber: number
+): string[] {
   // self-assign
   if (candidates.length === 1) {
     return candidates
   }
 
-  const withoutOwner = candidates.filter(
-    reviewer => owner !== reviewer
+  const withoutOwnerAndSender = candidates.filter(
+    reviewer => owner !== reviewer && sender !== reviewer
   )
 
   // all-assign
   if (desiredNumber === 0) {
-    return withoutOwner
+    return withoutOwnerAndSender
   }
 
-  return _.sampleSize(withoutOwner, desiredNumber)
+  return _.sampleSize(withoutOwnerAndSender, desiredNumber)
 }
 
 export function includesSkipKeywords (title: string, skipKeywords: string[]): boolean {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -21,6 +21,9 @@ describe('handlePullRequest', () => {
           owner: {
             login: 'kentaro-m'
           }
+        },
+        sender: {
+          login: 'testUser'
         }
       }
     }
@@ -32,7 +35,7 @@ describe('handlePullRequest', () => {
         addAssignees: true,
         addReviewers: true,
         numberOfReviewers: 0,
-        reviewers: ['reviewer1', 'reviewer2', 'reviewer3'],
+        reviewers: ['reviewer1', 'reviewer2', 'reviewer3', 'testUser'],
         skipKeywords: ['wip']
       }
     })
@@ -95,7 +98,7 @@ describe('handlePullRequest', () => {
         addAssignees: true,
         addReviewers: false,
         numberOfReviewers: 0,
-        reviewers: ['reviewer1', 'reviewer2', 'reviewer3'],
+        reviewers: ['reviewer1', 'reviewer2', 'reviewer3', 'testUser'],
         skipKeywords: ['wip']
       }
     })
@@ -128,7 +131,7 @@ describe('handlePullRequest', () => {
         assignees: ['assignee1'],
         numberOfAssignees: 1,
         numberOfReviewers: 0,
-        reviewers: ['reviewer1', 'reviewer2', 'reviewer3'],
+        reviewers: ['reviewer1', 'reviewer2', 'reviewer3', 'testUser'],
         skipKeywords: ['wip']
       }
     })
@@ -160,7 +163,7 @@ describe('handlePullRequest', () => {
         addReviewers: true,
         assignees: ['assignee1', 'assignee2', 'assignee3'],
         numberOfReviewers: 2,
-        reviewers: ['reviewer1', 'reviewer2', 'reviewer3'],
+        reviewers: ['reviewer1', 'reviewer2', 'reviewer3', 'testUser'],
         skipKeywords: ['wip']
       }
     })

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -98,7 +98,7 @@ describe('handlePullRequest', () => {
     )
   })
 
-  test('adds assignees to pull requests if the configuration is enabled ', async () => {
+  test('adds reviewers to assignees to pull requests if the configuration is enabled ', async () => {
     context.config = jest.fn().mockImplementation(async () => {
       return {
         addAssignees: true,
@@ -127,10 +127,10 @@ describe('handlePullRequest', () => {
 
     await handlePullRequest(context)
 
-    expect(addAssigneesSpy.mock.calls[0][0].assignees).toHaveLength(4)
+    expect(addAssigneesSpy.mock.calls[0][0].assignees).toHaveLength(3)
     expect(addAssigneesSpy.mock.calls[0][0].assignees[0]).toMatch(/reviewer/)
     expect(addAssigneesSpy.mock.calls[0][0].assignees).toEqual(expect.arrayContaining([
-      'reviewer1', 'reviewer2', 'reviewer3', 'pr-creator'
+      'reviewer1', 'reviewer2', 'reviewer3'
     ]))
     expect(createReviewRequestSpy).not.toBeCalled()
   })
@@ -209,7 +209,7 @@ describe('handlePullRequest', () => {
     )
   })
 
-  test('adds assignees to pull requests if the assigness are only the pr creator', async () => {
+  test("doesn't add assignees if the reviewers contain only a pr creator and assignees are not explicit", async () => {
     context.config = jest.fn().mockImplementation(async () => {
       return {
         addAssignees: true,
@@ -238,8 +238,7 @@ describe('handlePullRequest', () => {
 
     await handlePullRequest(context)
 
-    expect(addAssigneesSpy.mock.calls[0][0].assignees).toHaveLength(1)
-    expect(addAssigneesSpy.mock.calls[0][0].assignees[0]).toMatch(/pr-creator/)
+    expect(addAssigneesSpy).not.toHaveBeenCalled()
     expect(createReviewRequestSpy).not.toHaveBeenCalled()
   })
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -13,7 +13,7 @@ describe('chooseUsers', () => {
 
   test('returns the only other reviewer', () => {
     const prCreator = 'pr-creator'
-    const reviewers = ['reviewer1']
+    const reviewers = ['reviewer1', 'pr-creator']
     const numberOfReviewers = 1
 
     const list = chooseUsers(reviewers, numberOfReviewers, prCreator)

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,48 +1,53 @@
 import { chooseUsers, includesSkipKeywords } from '../src/util'
 
 describe('chooseUsers', () => {
-  test('returns the reviewer list without the owner', () => {
-    const owner = 'owner'
-    const sender = 'sender'
-    const reviewers = ['owner','reviewer1','reviewer2', 'reviewer3', 'sender']
+  test('returns the reviewer list without the PR creator', () => {
+    const prCreator = 'pr-creator'
+    const reviewers = ['reviewer1','reviewer2', 'reviewer3', 'pr-creator']
     const numberOfReviewers = 0
 
-    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
+    const list = chooseUsers(reviewers, numberOfReviewers, prCreator)
 
     expect(list).toEqual(['reviewer1','reviewer2', 'reviewer3'])
   })
 
   test('returns the only other reviewer', () => {
-    const owner = 'owner'
-    const sender = 'sender'
-    const reviewers = ['owner','reviewer1']
+    const prCreator = 'pr-creator'
+    const reviewers = ['reviewer1']
     const numberOfReviewers = 1
 
-    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
+    const list = chooseUsers(reviewers, numberOfReviewers, prCreator)
 
     expect(list).toEqual(['reviewer1'])
   })
 
   test('returns the reviewer list if the number of reviewers is setted', () => {
-    const owner = 'owner'
-    const sender = 'sender'
-    const reviewers = ['owner','reviewer1','reviewer2', 'reviewer3', 'sender']
+    const prCreator = 'pr-creator'
+    const reviewers = ['reviewer1','reviewer2', 'reviewer3', 'pr-creator']
     const numberOfReviewers = 2
 
-    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
+    const list = chooseUsers(reviewers, numberOfReviewers, prCreator)
 
     expect(list.length).toEqual(2)
   })
 
-  test('returns the only owner if if the number of reviewers is one', () => {
-    const owner = 'owner'
-    const sender = 'sender'
-    const reviewers = ['owner']
+  test('returns empty array if the reviewer is the PR creator', () => {
+    const prCreator = 'pr-creator'
+    const reviewers = ['pr-creator']
     const numberOfReviewers = 0
 
-    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
+    const list = chooseUsers(reviewers, numberOfReviewers, prCreator)
 
-    expect(list.length).toEqual(1)
+    expect(list.length).toEqual(0)
+  })
+
+  test('returns full reviewer array if not passing the user to filter out', () => {
+    const reviewers = ['pr-creator']
+    const numberOfReviewers = 0
+
+    const list = chooseUsers(reviewers, numberOfReviewers)
+
+    expect(list).toEqual(expect.arrayContaining(['pr-creator']))
   })
 })
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -3,40 +3,44 @@ import { chooseUsers, includesSkipKeywords } from '../src/util'
 describe('chooseUsers', () => {
   test('returns the reviewer list without the owner', () => {
     const owner = 'owner'
-    const reviewers = ['owner','reviewer1','reviewer2', 'reviewer3']
+    const sender = 'sender'
+    const reviewers = ['owner','reviewer1','reviewer2', 'reviewer3', 'sender']
     const numberOfReviewers = 0
 
-    const list = chooseUsers(owner, reviewers, numberOfReviewers)
+    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
 
     expect(list).toEqual(['reviewer1','reviewer2', 'reviewer3'])
   })
 
   test('returns the only other reviewer', () => {
     const owner = 'owner'
+    const sender = 'sender'
     const reviewers = ['owner','reviewer1']
     const numberOfReviewers = 1
 
-    const list = chooseUsers(owner, reviewers, numberOfReviewers)
+    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
 
     expect(list).toEqual(['reviewer1'])
   })
 
   test('returns the reviewer list if the number of reviewers is setted', () => {
     const owner = 'owner'
-    const reviewers = ['owner','reviewer1','reviewer2', 'reviewer3']
+    const sender = 'sender'
+    const reviewers = ['owner','reviewer1','reviewer2', 'reviewer3', 'sender']
     const numberOfReviewers = 2
 
-    const list = chooseUsers(owner, reviewers, numberOfReviewers)
+    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
 
     expect(list.length).toEqual(2)
   })
 
   test('returns the only owner if if the number of reviewers is one', () => {
     const owner = 'owner'
+    const sender = 'sender'
     const reviewers = ['owner']
     const numberOfReviewers = 0
 
-    const list = chooseUsers(owner, reviewers, numberOfReviewers)
+    const list = chooseUsers(owner, sender, reviewers, numberOfReviewers)
 
     expect(list.length).toEqual(1)
   })


### PR DESCRIPTION
Scenario:
I have a project where I require all contributors to review each others PR.

AS IS:
Github will ignore the 'reviewers' as it will always contain the creator of the PR. Github in such case will ignore the whole request.

TO BE:
Auto-assign will set the 'reviewers' property with all defined users, but every time it will skip the creator of the PR.