### PR TITLE
Fix a bug that infinite loop when run the app using nodemon

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "verbose": true,
+  "watch": ["src"],
+  "ext": "ts",
+  "exec": "npm start"
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "nodemon --exec \"npm start\"",
+    "dev": "nodemon",
     "start": "npm run build && probot run ./lib/index.js",
     "lint": "eslint src/**/*.ts",
     "test": "jest",


### PR DESCRIPTION
## Description
- Fix a bug that infinite loop when run the app using nodemon
  - The nodemon was restarting the app triggered by a TypeScript build event (`npm run build`)