### PR TITLE
feat: add ability to skip the process for specific users

### DIFF
--- a/.github/auto_assign_example.yml
+++ b/.github/auto_assign_example.yml
@@ -54,3 +54,7 @@ numberOfReviewers: 0
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
 # skipKeywords:
 #   - wip
+
+# A list of users to be skipped by both the add reviewers and add assignees processes
+# skipUsers:
+#   - dependabot[bot]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ numberOfReviewers: 0
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
 # skipKeywords:
 #   - wip
+
+# A list of users to be skipped by both the add reviewers and add assignees processes
+# skipUsers:
+#   - dependabot[bot]
 ```
 
 #### Add Github Team to Single Reviewers List

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,6 +13,7 @@ export interface Config {
   useAssigneeGroups: boolean
   reviewGroups: { [key: string]: string[] }
   assigneeGroups: { [key: string]: string[] }
+  skipUsers: string[]
 }
 
 export async function handlePullRequest(context: Context): Promise<void> {
@@ -31,6 +32,7 @@ export async function handlePullRequest(context: Context): Promise<void> {
     assigneeGroups,
     addReviewers,
     addAssignees,
+    skipUsers,
   } = config
 
   if (skipKeywords && includesSkipKeywords(title, skipKeywords)) {
@@ -55,6 +57,11 @@ export async function handlePullRequest(context: Context): Promise<void> {
   }
 
   const owner = context.payload.pull_request.user.login
+
+  if (skipUsers && skipUsers.includes(owner)) {
+    context.log(`ignore for user ${owner}`)
+    return
+  }
 
   if (addReviewers) {
     try {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -211,7 +211,7 @@ describe('handlePullRequest', () => {
       }
     })
 
-    context.octokit.issues = { 
+    context.octokit.issues = {
       addAssignees: jest.fn().mockImplementation(async () => {}),
     } as any
 
@@ -741,6 +741,7 @@ describe('handlePullRequest', () => {
           groupB: ['group2-user1'],
           groupC: ['group3-user1', 'group3-user2', 'group3-user3'],
         },
+        skipUsers: ['other-user'],
       }
     })
 
@@ -811,5 +812,23 @@ describe('handlePullRequest', () => {
     expect(requestReviewersSpy.mock.calls[0][0]?.reviewers?.[3]).toMatch(
       /group3-reviewer/
     )
+  })
+
+  test('skips for listed users', async () => {
+    // MOCKS
+    const spy = jest.spyOn(context, 'log')
+
+    // GIVEN
+    context.config = jest.fn().mockImplementation(async () => {
+      return {
+        skipUsers: ['pr-creator'],
+      }
+    })
+
+    // WHEN
+    await handlePullRequest(context)
+
+    // THEN
+    expect(spy.mock.calls[0][0]).toEqual('ignore for user pr-creator')
   })
 })

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -815,8 +815,21 @@ describe('handlePullRequest', () => {
   })
 
   test('skips for listed users', async () => {
-    // MOCKS
+    // MOCKS and STUBS
     const spy = jest.spyOn(context, 'log')
+
+    context.octokit.issues = {
+      addAssignees: jest.fn().mockImplementation(async () => {}),
+    } as any
+    const addAssigneesSpy = jest.spyOn(context.octokit.issues, 'addAssignees')
+
+    context.octokit.pulls = {
+      requestReviewers: jest.fn().mockImplementation(async () => {}),
+    } as any
+    const requestReviewersSpy = jest.spyOn(
+      context.octokit.pulls,
+      'requestReviewers'
+    )
 
     // GIVEN
     context.config = jest.fn().mockImplementation(async () => {
@@ -830,5 +843,7 @@ describe('handlePullRequest', () => {
 
     // THEN
     expect(spy.mock.calls[0][0]).toEqual('ignore for user pr-creator')
+    expect(requestReviewersSpy).not.toBeCalled()
+    expect(addAssigneesSpy).not.toBeCalled()
   })
 })


### PR DESCRIPTION
Hello

Thank you very much for this great application.
:heart:

My CI processes include auto approving PRs from bots, i.e. `dependabot`,
I'm missing the ability to skip adding reviewers and assignees for PRs opened by these specific bots,
I think it might be useful for others too.
:smiley:

