### PR TITLE
fix: fix addAssignees type

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,7 +3,7 @@ import { includesSkipKeywords, chooseAssignees, chooseReviewers } from './util'
 
 export interface Config {
   addReviewers: boolean
-  addAssignees: boolean
+  addAssignees: boolean | 'author'
   reviewers: string[]
   assignees: string[]
   numberOfAssignees: number


### PR DESCRIPTION
The type of `addAssignees` has been modified as it can accept strings as well as boolean values.