### PR TITLE
fix numberOfAssignees is overwritten by numberOfReviewers when 0 is set

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -113,13 +113,13 @@ export function chooseAssignees(owner: string, config: Config): string[] {
     chosenAssignees = chooseUsersFromGroups(
       owner,
       assigneeGroups,
-      numberOfAssignees || numberOfReviewers
+      numberOfAssignees ?? numberOfReviewers
     )
   } else {
     const candidates = assignees ? assignees : reviewers
     chosenAssignees = chooseUsers(
       candidates,
-      numberOfAssignees || numberOfReviewers,
+      numberOfAssignees ?? numberOfReviewers,
       owner
     ).users
   }


### PR DESCRIPTION
## Description
I fixed an issue https://github.com/kentaro-m/auto-assign/issues/177 which `numberOfAssignees` is overwritten by `numberOfReviewers` when 0 is set.