### PR TITLE
docs: update readme about team assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ numberOfReviewers: 0
 
 >Note: This feature is not enabled in the hosted app below.  
 https://github.com/apps/auto-assign  
-To enable the team assign, you need to host your own app and change the permission that the app can read the organization's team.  
+To enable the team assignment, you need to host your own app and change the permission that the app can read the organization's team.  
 
 ### Multiple Reviewers List
 Add reviewers/assignees to the pull request based on multiple reviewers list.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ numberOfReviewers: 0
 
 >Note: Number of reviewers has currently no impact on Github teams and all teams will be added as reviewers.
 
+>Note: This feature is not enabled in the hosted app below.  
+https://github.com/apps/auto-assign  
+To enable the team assign, you need to host your own app and change the permission that the app can read the organization's team.  
+
 ### Multiple Reviewers List
 Add reviewers/assignees to the pull request based on multiple reviewers list.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ numberOfReviewers: 0
 
 >Note: This feature is not enabled in the hosted app below.  
 https://github.com/apps/auto-assign  
-To enable the team assignment, you need to host your own app and change the permission that the app can read the organization's team.  
+To enable the team assignment, you need to host your own app and change the permission below that the app can read the organization's team.  
+- Repository permissions
+  - `Administration` - `Read-Only`
+- Organization permissions
+  - `Members` - `Read-Only`
 
 ### Multiple Reviewers List
 Add reviewers/assignees to the pull request based on multiple reviewers list.


### PR DESCRIPTION
Hi Kentaro,

Thank you so much for the great application! 👍

As we discussed in https://github.com/kentaro-m/auto-assign/issues/207, I suppose that we need to mention the team assignment feature is not enabled in the hosted auto-assign app.

I created a pull request to modify README.md and would like you to check it.

Thank you.