### PR TITLE
fix: simplify start script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "nodemon",
-    "start": "npm run build && probot run ./lib/index.js",
+    "start": "probot run ./lib/index.js",
     "lint": "eslint src/**/*.ts",
     "test": "jest",
     "coverage": "jest --coverage",


### PR DESCRIPTION
This pull request updates the `start` script in the `package.json` file to streamline the development workflow by removing the build step.

Changes to `package.json`:

* The `start` script no longer includes the `npm run build` command, assuming the build step is handled separately or is unnecessary for starting the application. (`[package.jsonL18-R18](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R18)`)